### PR TITLE
商品購入確認ページの作成

### DIFF
--- a/app/assets/stylesheets/buy.scss
+++ b/app/assets/stylesheets/buy.scss
@@ -300,6 +300,7 @@
   }
 }
 
+
 @media (min-width: 768px) {
   .buy-shrink {
     display: none;

--- a/app/assets/stylesheets/buy.scss
+++ b/app/assets/stylesheets/buy.scss
@@ -87,24 +87,17 @@
             }
           }
         }
-        &__announcement {
-          margin-top: 8px;
-          color: #FF0211;
-        }
         &__finish {
-          margin-top: 8px;
+          cursor: pointer;
           margin-bottom: 15px;
-          background-color: #888;
+          background-color: #FF0211;
           height: 50px;
           width: 100%;
           border-bottom: 1px solid #f5f5f5;
-          &--button {
-            text-decoration: none;
-            font-weight: bold;
-            color: #FFF;
-            font-size: 14px;
-            text-align: center;
-        }
+          font-weight: bold;
+          color: #FFF;
+          font-size: 14px;
+          text-align: center;
         }
       }
     }
@@ -247,19 +240,16 @@
           color: #FF0211;
         }
         &__finish {
-          margin-top: 8px;
+          cursor: pointer;
           margin-bottom: 15px;
-          background-color: #888;
+          background-color: #FF0211;
           height: 50px;
           width: 100%;
           border-bottom: 1px solid #f5f5f5;
-          &--button {
-            text-decoration: none;
-            font-weight: bold;
-            color: #FFF;
-            font-size: 14px;
-            text-align: center;
-        }
+          font-weight: bold;
+          color: #FFF;
+          font-size: 14px;
+          text-align: center;
         }
       }
     }

--- a/app/views/items/buy.html.haml
+++ b/app/views/items/buy.html.haml
@@ -11,7 +11,7 @@
         = image_tag 'top_phone.png', alt: 'prpduct', class: 'center__item__photo--product'
       %p.center__item__name
         商品名
-      %form.center__item__form
+      %form{action: '#', class: 'center__item__form'}
         .center__item__form__total
           ¥1,000
         .center__item__form__specified
@@ -27,11 +27,8 @@
             .center__item__form__price__pay__figure
               %span.center__item__form__price__pay__figure__yen
                 ¥1,000
-        %p.center__item__form__announcement
-          配送先と支払い方法の入力を完了して下さい。
         %button{class: 'center__item__form__finish'}
-          = link_to '#', class: 'center__item__form__finish--button' do
-            購入する
+          購入する
     %section.center__address
       .center__address__box
         %h3.center__address__box__title
@@ -60,7 +57,7 @@
         = image_tag 'top_phone.png', alt: 'prpduct', class: 'center__item__photo--product'
       %p.center__item__name
         商品名
-      %form.center__item__form
+      %form{action: '#', class: 'center__item__form'}
         .center__item__form__total
           ¥1,000
         .center__item__form__specified
@@ -76,11 +73,8 @@
             .center__item__form__price__pay__figure
               %span.center__item__form__price__pay__figure__yen
                 ¥1,000
-        %p.center__item__form__announcement
-          配送先と支払い方法の入力を完了して下さい。
         %button{class: 'center__item__form__finish'}
-          = link_to '#', class: 'center__item__form__finish--button' do
-            購入する
+          購入する
     %section.center__address
       .center__address__box
         %h3.center__address__box__title


### PR DESCRIPTION
## What
ログインユーザーが出品されている商品を購入する際に表示される確認ページ

## Why
メルカリの実装において、次のビューページ作成ができるようにするため。

## 完了の定義
https://www.mercari.com/jp/transaction/buy/m70068440240/ (商品購入確認ページならどれでも良いです)
と同じ見た目ができている
