### PR TITLE
本人確認ページのビュー

### DIFF
--- a/app/assets/stylesheets/identification.scss
+++ b/app/assets/stylesheets/identification.scss
@@ -1,1 +1,347 @@
 // ユーザー本人確認ページ users/edit
+
+.identification {
+  width: 1020px;
+  a {
+    text-decoration: none;
+    color: #333;
+  }
+  margin: 38px auto 0;
+  padding-bottom: 80px;
+  .person {
+    background-color: #fff;
+    margin-left: 320px;
+    &__title {
+      padding: 8px 24px;
+      font-weight: bold;
+      text-align: center;
+      font-size: 24px;
+      border-bottom: 2px solid #eee;
+    }
+    &__inner {
+      padding: 65px;
+        &__announce {
+          height: 71px;
+          margin-top: 8px;
+          .update-link {
+            margin-top: 8px;
+            float: right;
+            text-decoration: none;
+            color: #0099e8;
+          }
+        }
+        &__name {
+          margin-top: 38px;
+          &__title {
+            font-weight: bold;
+          }
+          &__user {
+            margin-top: 6px;
+          }
+        }
+        &__city {
+          margin-top: 40px;
+          &__title {
+            font-weight: bold;
+            display: inline-block;
+          }
+          &__need {
+            font-size: 12px;
+            padding: 3px;
+            color: #FFF;
+            background-color: #ccc;
+            font-weight: none;
+            border-radius: 3px;
+          }
+          &--folder {
+            height: 48px;
+            margin-top: 8px;
+            width: 100%;
+            position: relative;
+            font-weight: none;
+            border: 1px solid #ccc;
+            border-radius: 6px;
+            font-size: 15px;
+            padding: 8px 14px;
+          }
+          &__box {
+          }
+          #_prefecture_id {
+            background-color: #FFF;
+            height: 48px;
+            margin-top: 8px;
+            width: 100%;
+            position: relative;
+            font-weight: none;
+            border: 1px solid #ccc;
+            border-radius: 6px;
+            font-size: 15px;
+            padding: 8px 14px;
+          }
+        }
+        &__registration {
+          margin-top: 40px;
+          background-color: #FF0211;
+          font-size: 14px;
+          text-align: center;
+          display: block;
+          width: 100%;
+          cursor: pointer;
+          line-height: 48px;
+          color: #FFF;
+          text-decoration: none;
+        }
+        &__about {
+          text-align: right;
+          margin-top: 40px;
+          .link {
+              text-align: right;
+              margin-top: 8px;
+              text-decoration: none;
+              color: #0099e8;
+            }
+        }
+    }
+  }
+}
+
+.identification-shrink {
+  margin: 24px auto 0;
+  width: 700px;
+  padding-bottom: 40px;
+  display: block;
+  a {
+    text-decoration: none;
+    color: #333;
+  }
+  .person {
+    display: block;
+    background-color: #fff;
+    &__title {
+      padding: 8px 24px;
+      font-weight: bold;
+      text-align: center;
+      font-size: 24px;
+      border-bottom: 2px solid #eee;
+    }
+    &__inner {
+      padding: 65px;
+        &__announce {
+          height: 71px;
+          margin-top: 8px;
+          .update-link {
+            margin-top: 8px;
+            float: right;
+            text-decoration: none;
+            color: #0099e8;
+          }
+        }
+        &__name {
+          margin-top: 38px;
+          &__title {
+            font-weight: bold;
+          }
+          &__user {
+            margin-top: 6px;
+          }
+        }
+        &__city {
+          margin-top: 40px;
+          &__title {
+            font-weight: bold;
+            display: inline-block;
+          }
+          &__need {
+            font-size: 12px;
+            padding: 3px;
+            color: #FFF;
+            background-color: #ccc;
+            font-weight: none;
+            border-radius: 3px;
+          }
+          &--folder {
+            height: 48px;
+            margin-top: 8px;
+            width: 100%;
+            position: relative;
+            font-weight: none;
+            border: 1px solid #ccc;
+            border-radius: 6px;
+            font-size: 15px;
+            padding: 8px 14px;
+          }
+          &__box {
+          }
+          #_prefecture_id {
+            background-color: #FFF;
+            height: 48px;
+            margin-top: 8px;
+            width: 100%;
+            position: relative;
+            font-weight: none;
+            border: 1px solid #ccc;
+            border-radius: 6px;
+            font-size: 15px;
+            padding: 8px 14px;
+          }
+        }
+        &__registration {
+          margin-top: 40px;
+          background-color: #FF0211;
+          font-size: 14px;
+          text-align: center;
+          display: block;
+          width: 100%;
+          cursor: pointer;
+          line-height: 48px;
+          color: #FFF;
+          text-decoration: none;
+        }
+        &__about {
+          text-align: right;
+          margin-top: 40px;
+          .link {
+              text-align: right;
+              margin-top: 8px;
+              text-decoration: none;
+              color: #0099e8;
+            }
+        }
+    }
+  }
+}
+
+.identification-more-shrink {
+  margin-top: 24px;
+  padding-bottom: 40px;
+  a {
+    text-decoration: none;
+    color: #333;
+  }
+  .person {
+    width: 100%;
+    background-color: #fff;
+    &__title {
+      padding: 8px 24px;
+      font-weight: bold;
+      text-align: center;
+      font-size: 18px;
+      border-bottom: 2px solid #eee;
+    }
+    &__inner {
+      padding: 40px;
+        &__announce {
+          height: 71px;
+          margin-top: 8px;
+          .update-link {
+            margin-top: 8px;
+            float: right;
+            text-decoration: none;
+            color: #0099e8;
+          }
+        }
+        &__name {
+          margin-top: 38px;
+          &__title {
+            font-weight: bold;
+          }
+          &__user {
+            margin-top: 6px;
+          }
+        }
+        &__city {
+          margin-top: 40px;
+          &__title {
+            font-weight: bold;
+            display: inline-block;
+          }
+          &__need {
+            margin-left: 7px;
+            font-size: 12px;
+            padding: 3px;
+            color: #FFF;
+            background-color: #ccc;
+            font-weight: none;
+            border-radius: 3px;
+          }
+          &--folder {
+            height: 48px;
+            margin-top: 8px;
+            width: 100%;
+            position: relative;
+            font-weight: none;
+            border: 1px solid #ccc;
+            border-radius: 6px;
+            font-size: 15px;
+            padding: 8px 14px;
+          }
+          &__box {
+          }
+          #_prefecture_id {
+            background-color: #FFF;
+            height: 48px;
+            margin-top: 8px;
+            width: 100%;
+            position: relative;
+            font-weight: none;
+            border: 1px solid #ccc;
+            border-radius: 6px;
+            font-size: 15px;
+            padding: 8px 14px;
+          }
+        }
+        &__registration {
+          margin-top: 40px;
+          background-color: #FF0211;
+          font-size: 14px;
+          text-align: center;
+          display: block;
+          width: 100%;
+          cursor: pointer;
+          line-height: 48px;
+          color: #FFF;
+          text-decoration: none;
+        }
+        &__about {
+          text-align: right;
+          margin-top: 40px;
+          .link {
+              text-align: right;
+              margin-top: 8px;
+              text-decoration: none;
+              color: #0099e8;
+            }
+        }
+    }
+  }
+}
+
+@media (min-width: 1068px) {
+  .identification-shrink {
+    display: none;
+  }
+  .identification-more-shrink {
+    display: none;
+  }
+}
+
+@media (max-width: 1067px) {
+  .identification {
+    display: none;
+  }
+}
+
+@media (min-width: 768px) {
+  .identification-more-shrink {
+    display: none;
+  }
+}
+
+@media (max-width: 767px) {
+  .identification {
+    display: none;
+  }
+  .identification-shrink {
+    display: none;
+  }
+}

--- a/app/views/users/address.html.haml
+++ b/app/views/users/address.html.haml
@@ -1,0 +1,173 @@
+-# ユーザー本人確認ページ
+
+
+= render 'shared/header'
+
+.identification
+  = render 'shared/user_sidebar'
+  %section.person
+    %h2.person__title
+      本人情報の登録
+    %form.person__flame
+      .person__inner
+        = form_for root_path, method: :post do |f|
+          .person__inner__announce
+            %p
+              お客さまの本人情報をご登録ください。
+            %p
+              登録されたお名前・生年月日を変更する場合、本人確認書類の提出が必要になります。
+            = link_to '本人確認書類のアップデートについて＞', '#', class: 'update-link'
+          .person__inner__name
+            %label.person__inner__name__title
+              お名前
+            %p.person__inner__name__user
+              大阪 太郎
+          .person__inner__name
+            %label.person__inner__name__title
+              お名前カナ
+            %p.person__inner__name__user
+              オオサカ タロウ
+          .person__inner__name
+            %label.person__inner__name__title
+              生年月日
+            %p.person__inner__name__user
+              2001/01/01
+          .person__inner__city
+            %label.person__inner__city__title 郵便番号
+            %span.person__inner__city__need 任意
+            %input{placeholder: '例）1234567', class: 'person__inner__city--folder'}
+          .person__inner__city
+            %label.person__inner__city__title 都道府県
+            %span.person__inner__city__need 任意
+            .person__inner__city__box
+              = f.collection_select :prefecture_id, Prefecture.all, :id, :name
+          .person__inner__city
+            %label.person__inner__city__title 市区町村
+            %span.person__inner__city__need 任意
+            %input{placeholder: '例）横浜市緑区', class: 'person__inner__city--folder'}
+          .person__inner__city
+            %label.person__inner__city__title 番地
+            %span.person__inner__city__need 任意
+            %input{placeholder: '例）青山1-1-1', class: 'person__inner__city--folder'}
+          .person__inner__city
+            %label.person__inner__city__title 建物名
+            %span.person__inner__city__need 任意
+            %input{placeholder: '例）柳ビル103', class: 'person__inner__city--folder'}
+          %button{type: 'submit', class: 'person__inner__registration'} 登録する
+          .person__inner__about
+            = link_to '本人情報の登録について＞', '#', class: 'link'
+
+
+.identification-shrink
+  %section.person
+    %h2.person__title
+      本人情報の登録
+    %form.person__flame
+      .person__inner
+        = form_for root_path, method: :post do |f|
+          .person__inner__announce
+            %p
+              お客さまの本人情報をご登録ください。
+            %p
+              登録されたお名前・生年月日を変更する場合、本人確認書類の提出が必要になります。
+            = link_to '本人確認書類のアップデートについて＞', '#', class: 'update-link'
+          .person__inner__name
+            %label.person__inner__name__title
+              お名前
+            %p.person__inner__name__user
+              大阪 太郎
+          .person__inner__name
+            %label.person__inner__name__title
+              お名前カナ
+            %p.person__inner__name__user
+              オオサカ タロウ
+          .person__inner__name
+            %label.person__inner__name__title
+              生年月日
+            %p.person__inner__name__user
+              2001/01/01
+          .person__inner__city
+            %label.person__inner__city__title 郵便番号
+            %span.person__inner__city__need 任意
+            %input{placeholder: '例）1234567', class: 'person__inner__city--folder'}
+          .person__inner__city
+            %label.person__inner__city__title 都道府県
+            %span.person__inner__city__need 任意
+            .person__inner__city__box
+              = f.collection_select :prefecture_id, Prefecture.all, :id, :name
+          .person__inner__city
+            %label.person__inner__city__title 市区町村
+            %span.person__inner__city__need 任意
+            %input{placeholder: '例）横浜市緑区', class: 'person__inner__city--folder'}
+          .person__inner__city
+            %label.person__inner__city__title 番地
+            %span.person__inner__city__need 任意
+            %input{placeholder: '例）青山1-1-1', class: 'person__inner__city--folder'}
+          .person__inner__city
+            %label.person__inner__city__title 建物名
+            %span.person__inner__city__need 任意
+            %input{placeholder: '例）柳ビル103', class: 'person__inner__city--folder'}
+          %button{type: 'submit', class: 'person__inner__registration'} 登録する
+          .person__inner__about
+            = link_to '本人情報の登録について＞', '#', class: 'link'
+  = render 'shared/user_sidebar'
+
+
+.identification-more-shrink
+  %section.person
+    %h2.person__title
+      本人情報の登録
+    %form.person__flame
+      .person__inner
+        = form_for root_path, method: :post do |f|
+          .person__inner__announce
+            %p
+              お客さまの本人情報をご登録ください。
+            %p
+              登録されたお名前・生年月日を変更する場合、本人確認書類の提出が必要になります。
+            = link_to '本人確認書類のアップデートについて＞', '#', class: 'update-link'
+          .person__inner__name
+            %label.person__inner__name__title
+              お名前
+            %p.person__inner__name__user
+              大阪 太郎
+          .person__inner__name
+            %label.person__inner__name__title
+              お名前カナ
+            %p.person__inner__name__user
+              オオサカ タロウ
+          .person__inner__name
+            %label.person__inner__name__title
+              生年月日
+            %p.person__inner__name__user
+              2001/01/01
+          .person__inner__city
+            %label.person__inner__city__title 郵便番号
+            %span.person__inner__city__need 任意
+            %input{placeholder: '例）1234567', class: 'person__inner__city--folder'}
+          .person__inner__city
+            %label.person__inner__city__title 都道府県
+            %span.person__inner__city__need 任意
+            .person__inner__city__box
+              = f.collection_select :prefecture_id, Prefecture.all, :id, :name
+          .person__inner__city
+            %label.person__inner__city__title 市区町村
+            %span.person__inner__city__need 任意
+            %input{placeholder: '例）横浜市緑区', class: 'person__inner__city--folder'}
+          .person__inner__city
+            %label.person__inner__city__title 番地
+            %span.person__inner__city__need 任意
+            %input{placeholder: '例）青山1-1-1', class: 'person__inner__city--folder'}
+          .person__inner__city
+            %label.person__inner__city__title 建物名
+            %span.person__inner__city__need 任意
+            %input{placeholder: '例）柳ビル103', class: 'person__inner__city--folder'}
+          %button{type: 'submit', class: 'person__inner__registration'} 登録する
+          .person__inner__about
+            = link_to '本人情報の登録について＞', '#', class: 'link'
+  = render 'shared/user_sidebar'
+
+= render 'shared/camera'
+
+= render 'shared/footer'
+


### PR DESCRIPTION
What
ユーザー本人確認ページのコーディング

Why
メルカリのユーザー本人確認ページ実装のために必要だから。

完了の定義
https://www.mercari.com/jp/mypage/identification/
と同じ見た目ができている

上部分
https://gyazo.com/197760585e0a94e3fd0845ca0b587f5b
下部分
https://gyazo.com/2d09a0eb54c9d7d97021750e5665e2a7