### PR TITLE
クレジットカード登録ページ（クレカ追加画面）作成

### DIFF
--- a/app/assets/stylesheets/cards/card_new.scss
+++ b/app/assets/stylesheets/cards/card_new.scss
@@ -1,75 +1,75 @@
 .new {
-    &__main__section {
-        margin: 40px auto 0;
-        width: 1020px;
-        height: 1292px;
-        display: flex;
+  &__main__section {
+      margin: 40px auto 0;
+      width: 1020px;
+      height: 1292px;
+      display: flex;
 
-        &__content {
-            width: 700px;
-            height: 50px;
-            height: 358px;
-            background-color: white;
+    &__content {
+        width: 700px;
+        height: 50px;
+        height: 358px;
+        background-color: white;
 
-            &__box {
-                &__title {
-                    text-align: center;
-                    line-height: 1.4;
-                    padding: 12px 4%;
-                    border-bottom: 1px solid #f5f5f5;
-                    font-size: 24px;
-                    font-weight: bold;
+      &__box {
+        &__title {
+            text-align: center;
+            line-height: 1.4;
+            padding: 12px 4%;
+            border-bottom: 1px solid #f5f5f5;
+            font-size: 24px;
+            font-weight: bold;
 
-                    &__text {
-                        font-weight: bold;
-                    }
-                }
-
-                &__card {
-                    border-top: 1px solid #f5f5f5;
-                    padding: 64px;
-                    height: 308px;
-
-                    &__text {
-                        font-size: 16px;
-                        font-weight: bold;
-                        margin-left: 16px;
-                        width: 320px;
-                        height: 15px;
-                        margin: 0 auto;
-                    }
-
-                    &__add {
-                        border-bottom: 1px solid #eee;
-                        margin: 0;
-                        padding: 24px 0;
-
-                        &__button {
-                            width: 320px;
-                            height: 50px;
-                            background-color: #ea352d;
-                            color: white;
-                            display: flex;
-                            margin: 0 auto;
-                            cursor: pointer;
-
-                            &__text {
-                                text-align: center;
-                            }
-                        }
-
-                        &__pay {
-                            margin: 40px 0 0;
-                            font: 14px;
-                            width: 572px;
-                            height: 16px;
-                            text-align: right;
-                        }
-                    }
-                }
+            &__text {
+                font-weight: bold;
             }
         }
+
+        &__card {
+            border-top: 1px solid #f5f5f5;
+            padding: 64px;
+            height: 308px;
+
+          &__text {
+              font-size: 16px;
+              font-weight: bold;
+              margin-left: 16px;
+              width: 320px;
+              height: 15px;
+              margin: 0 auto;
+          }
+
+          &__add {
+              border-bottom: 1px solid #eee;
+              margin: 0;
+              padding: 24px 0;
+
+            &__button {
+                width: 320px;
+                height: 50px;
+                background-color: #ea352d;
+                color: white;
+                display: flex;
+                margin: 0 auto;
+                cursor: pointer;
+
+                &__text {
+                    text-align: center;
+                }
+            }
+
+          &__pay {
+              margin: 40px 0 0;
+              font: 14px;
+              width: 572px;
+              height: 16px;
+              text-align: right;
+            }
+          }
+        }
+      }
     }
+  }
 
     a {
         text-decoration: none;

--- a/app/assets/stylesheets/cards/card_new.scss
+++ b/app/assets/stylesheets/cards/card_new.scss
@@ -1,0 +1,100 @@
+.new {
+    &__main__section {
+        margin: 40px auto 0;
+        width: 1020px;
+        height: 1292px;
+        display: flex;
+
+        &__content {
+            width: 700px;
+            height: 50px;
+            height: 358px;
+            background-color: white;
+
+            &__box {
+                &__title {
+                    text-align: center;
+                    line-height: 1.4;
+                    padding: 12px 4%;
+                    border-bottom: 1px solid #f5f5f5;
+                    font-size: 24px;
+                    font-weight: bold;
+
+                    &__text {
+                        font-weight: bold;
+                    }
+                }
+
+                &__card {
+                    border-top: 1px solid #f5f5f5;
+                    padding: 64px;
+                    height: 308px;
+
+                    &__text {
+                        font-size: 16px;
+                        font-weight: bold;
+                        margin-left: 16px;
+                        width: 320px;
+                        height: 15px;
+                        margin: 0 auto;
+                    }
+
+                    &__add {
+                        border-bottom: 1px solid #eee;
+                        margin: 0;
+                        padding: 24px 0;
+
+                        &__button {
+                            width: 320px;
+                            height: 50px;
+                            background-color: #ea352d;
+                            color: white;
+                            display: flex;
+                            margin: 0 auto;
+                            cursor: pointer;
+
+                            &__text {
+                                text-align: center;
+                            }
+                        }
+
+                        &__pay {
+                            margin: 40px 0 0;
+                            font: 14px;
+                            width: 572px;
+                            height: 16px;
+                            text-align: right;
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    a {
+        text-decoration: none;
+        color: #333;
+        width: 572px;
+        height: 16px;
+        display: inline;
+    }
+
+    .card-icon {
+        margin-left: 50px;
+        display: inline-block;
+        font-weight: bold;
+        font-variant: normal;
+        line-height: 1;
+        font-size: 20px;
+    }
+
+    .pay-link {
+        width: 572px;
+        height: 16px;
+        color: #0099ee;
+    }
+
+    .right-icon {
+        font-weight: bold;
+    }
+}

--- a/app/views/cards/new.html.haml
+++ b/app/views/cards/new.html.haml
@@ -1,1 +1,25 @@
-test new
+%section.new
+  =render 'shared/header'
+  .new__main__section
+    .new__main__section__side
+      =render 'shared/user_sidebar'
+    .new__main__section__content
+      .new__main__section__content__box
+        .new__main__section__content__box__title
+          %p.new__main__section__content__box__title__text
+          支払い方法
+        .new__main__section__content__box__card
+          %h3.new__main__section__content__box__card__text
+            クレジットカード一覧
+          .new__main__section__content__box__card__add
+            %button.new__main__section__content__box__card__add__button
+              =fa_icon 'credit-card',  class:"card-icon"
+              %p.new__main__section__content__box__card__add__button__text
+              　クレジットカードを追加する
+          .new__main__section__content__box__card__add__pay
+            =link_to "cards_create_path"  , class:"pay-link" do
+              %p.new__main__section__content__box__card__add__pay_text
+              支払い方法について
+              = fa_icon 'angle-right', class:"right-icon"
+=render 'shared/camera'
+=render 'shared/footer'

--- a/app/views/cards/new.html.haml
+++ b/app/views/cards/new.html.haml
@@ -17,7 +17,7 @@
               %p.new__main__section__content__box__card__add__button__text
               　クレジットカードを追加する
           .new__main__section__content__box__card__add__pay
-            =link_to "cards_create_path"  , class:"pay-link" do
+            =link_to cards_path  , class:"pay-link" do
               %p.new__main__section__content__box__card__add__pay_text
               支払い方法について
               = fa_icon 'angle-right', class:"right-icon"


### PR DESCRIPTION
# what
- クレジットカード登録ページ（クレカ追加画面）を作成した
- ヘッダー、サイドバー、フッターは部分テンプレート化しrenderで読み込んだ
- メイン画面はブロックにわけて、レイアウトした
# why
クレジットカード登録を行う最初のページを作成して、カード登録の実装を行うため

画像
https://i.gyazo.com/1d18eedeca361b585387e708556a3647.mp4